### PR TITLE
Slightly more robust fallocate detection

### DIFF
--- a/project/setup.sh
+++ b/project/setup.sh
@@ -50,8 +50,7 @@ else
     xflags=
 fi
 
-[[ -r /usr/include/bits/fcntl.h ]] \
-	&& grep -qw fallocate /usr/include/bits/fcntl.h \
+echo '#include <fcntl.h>' | gcc -E -D_GNU_SOURCE - | grep -qw 'fallocate' \
 	&& defines="$defines -DHAVE_FALLOCATE=1"
 
 [[ -r /usr/include/fcntl.h ]] \


### PR DESCRIPTION
This uses the compiler to try to detect if fallocate is available (should be on any Linux since 2.6.23). With the old check, fallocate is never found on modern systems, since the real header file where it is defined is somewhere at `/usr/include/<ARCH>/bits/fcntl-linux.h`.

Why is this useful? I noticed that `wit` is really slow (without showing progress) when copying images to an `ntfs-3g`-mounted partition. Since `ntfs-3g` doesn't implement ` fallocate`, `posix_fallocate` falls back to a very slow "emulation" ([manpage](https://manpages.debian.org/buster/manpages-dev/posix_fallocate.3.en.html#NOTES), [source](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/posix/posix_fallocate64.c;h=c1e233b49c8d7f37e005dd0f768374b0ce21e5ea;hb=HEAD))

PS: It would probably make sense to check the return value of `fallocate`/`posix_fallocate` for at lease `EOPNOTSUPP` to show a warning that the target filesystem doesn't support preallocation.

PPS: Feel free to take this contribution under any license you like (consider it BSD-0/GPL2+ dual-licensed ;))